### PR TITLE
fix exception type of some python-etcd api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
   - "2.7"
 
 before_install:
-  - wget https://github.com/coreos/etcd/releases/download/v0.2.0/etcd-v0.2.0-Linux-x86_64.tar.gz
-  - tar -zxvf etcd-v0.2.0-Linux-x86_64.tar.gz
-  - ./etcd-v0.2.0-Linux-x86_64/etcd &
+  - wget https://github.com/coreos/etcd/releases/download/v2.0.11/etcd-v2.0.11-linux-amd64.tar.gz
+  - tar -zxvf etcd-v2.0.11-linux-amd64.tar.gz
+  - ./etcd-v2.0.11-linux-amd64/etcd &
   - sleep 2
 
 install:

--- a/sherlock/lock.py
+++ b/sherlock/lock.py
@@ -534,7 +534,7 @@ class EtcdLock(BaseLock):
             self.client.write(self._key_name, owner,
                               prevExist=False, ttl=self.expire)
             self._owner = owner
-        except KeyError:
+        except etcd.EtcdAlreadyExist:
             return False
         else:
             return True
@@ -550,7 +550,7 @@ class EtcdLock(BaseLock):
         except ValueError:
             raise LockException('Lock could not be released because it '
                                 'was been acquired by this instance.')
-        except KeyError:
+        except etcd.EtcdKeyNotFound:
             raise LockException('Lock could not be released as it has not '
                                 'been acquired')
 
@@ -559,7 +559,7 @@ class EtcdLock(BaseLock):
         try:
             self.client.get(self._key_name)
             return True
-        except KeyError:
+        except etcd.EtcdKeyNotFound:
             return False
 
 

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -129,13 +129,13 @@ class TestEtcdLock(unittest.TestCase):
         lock = sherlock.EtcdLock(self.lock_name)
         lock._acquire()
         lock._release()
-        self.assertRaises(KeyError, self.client.get, self.lock_name)
+        self.assertRaises(etcd.EtcdKeyNotFound, self.client.get, self.lock_name)
 
     def test_release_with_namespace(self):
         lock = sherlock.EtcdLock(self.lock_name, namespace='ns')
         lock._acquire()
         lock._release()
-        self.assertRaises(KeyError, self.client.get, '/ns/%s' % self.lock_name)
+        self.assertRaises(etcd.EtcdKeyNotFound, self.client.get, '/ns/%s' % self.lock_name)
 
     def test_release_own_only(self):
         lock1 = sherlock.EtcdLock(self.lock_name)
@@ -157,16 +157,16 @@ class TestEtcdLock(unittest.TestCase):
         self.assertEqual(self.client.get(self.lock_name).value, str(lock._owner))
 
         del lock
-        self.assertRaises(KeyError, self.client.get, self.lock_name)
+        self.assertRaises(etcd.EtcdKeyNotFound, self.client.get, self.lock_name)
 
     def tearDown(self):
         try:
             self.client.delete(self.lock_name)
-        except KeyError:
+        except etcd.EtcdKeyNotFound:
             pass
         try:
             self.client.delete('/ns/%s' % self.lock_name)
-        except KeyError:
+        except etcd.EtcdKeyNotFound:
             pass
 
 class TestMCLock(unittest.TestCase):


### PR DESCRIPTION
Since the errorcode of etcd has changed in v2.0 and python-etcd only
supports etcd version 2.0.x or later, some Exception type generated
by etcd api call has changed. This commit corrects the Exception type
and upgrades the etcd version in travis to v2.0.11

Upgrade etcd from version 0.2.x to 2.0.x and also fix the latest travis
build failure.