### PR TITLE
This #fixes issue#17. Correct error in except statement to make it Python3 compatible

### DIFF
--- a/sherlock/lock.py
+++ b/sherlock/lock.py
@@ -204,7 +204,7 @@ class BaseLock(object):
     def __del__(self):
         try:
             self.release()
-        except LockException, err:
+        except LockException:
             pass
 
 


### PR DESCRIPTION
Support for Python 3.5, by correcting an exception syntax error.
